### PR TITLE
Make timed compile as a port without port patches

### DIFF
--- a/rc.d/timed
+++ b/rc.d/timed
@@ -13,7 +13,7 @@
 name="timed"
 desc="Time server daemon"
 rcvar="timed_enable"
-command="/usr/sbin/${name}"
+command="%%PREFIX%%/sbin/${name}"
 
 load_rc_config $name
 run_rc_command "$1"

--- a/timed/Makefile
+++ b/timed/Makefile
@@ -8,9 +8,6 @@ MAN=	timed.8
 SRCS=	acksend.c candidate.c correct.c master.c networkdelta.c readmsg.c \
 	slave.c timed.c byteorder.c measure.c cksum.c
 
-LIBADD=	util
+LDADD=	-l util
 
-WARNS?=	1
-
-.include "../../Makefile.inc"
 .include <bsd.prog.mk>

--- a/timed/measure.c
+++ b/timed/measure.c
@@ -65,7 +65,7 @@ static n_short seqno = 0;
 int					/* status val defined in globals.h */
 measure(u_long maxmsec, u_long wmsec, char *hname, struct sockaddr_in *addr, int print)
 {
-	int length;
+	socklen_t length;
 	int measure_status;
 	int rcvcount, trials;
 	int cc, count;

--- a/timed/readmsg.c
+++ b/timed/readmsg.c
@@ -73,7 +73,7 @@ struct timeval from_when;
 struct tsp *
 readmsg(int type, char *machfrom, struct timeval *intvl, struct netinfo *netfrom)
 {
-	int length;
+	socklen_t length;
 	fd_set ready;
 	static struct tsplist *head = &msgslist;
 	static struct tsplist *tail = &msgslist;

--- a/timedc/Makefile
+++ b/timedc/Makefile
@@ -6,10 +6,5 @@
 PROG=	timedc
 MAN=	timedc.8
 SRCS=	cmds.c cmdtab.c timedc.c byteorder.c measure.c cksum.c
-BINOWN=	root
-BINMODE= 4555
 
-WARNS?=	1
-
-.include "../../Makefile.inc"
 .include <bsd.prog.mk>

--- a/timedc/cmds.c
+++ b/timedc/cmds.c
@@ -86,7 +86,7 @@ daydiff(char *hostname)
 	struct timeval tout, now;
 	fd_set ready;
 	struct sockaddr from;
-	int fromlen;
+	socklen_t fromlen;
 	unsigned long sec;
 
 
@@ -266,7 +266,8 @@ msite(int argc, char *argv[])
 	ssize_t cc;
 	fd_set ready;
 	struct sockaddr_in dest;
-	int i, length;
+	int i;
+	socklen_t length;
 	struct sockaddr_in from;
 	struct timeval tout;
 	struct tsp msg;
@@ -419,7 +420,7 @@ void
 tracing(int argc, char *argv[])
 {
 	int onflag;
-	int length;
+	socklen_t length;
 	ssize_t cc;
 	fd_set ready;
 	struct sockaddr_in dest;


### PR DESCRIPTION
The changes are:
- the rc script expects the command in ${PREFIX}/sbin, not /usr/sbin
- use LDADD instead of LIBADD in the Makefiles and remove unnecessary lines (WARNS, BINOWN, BINMODE, .include)
- use socklen_t instead of int for the length parameter in recvfrom()

I'll commit the port when this repo has been moved over to freebsd/timed and tagged as version "1.0".